### PR TITLE
Fix frequent itemsets notebooks

### DIFF
--- a/Exercises/05.Frequent_Itemsets/Frequent_itemsets.ipynb
+++ b/Exercises/05.Frequent_Itemsets/Frequent_itemsets.ipynb
@@ -192,7 +192,7 @@
     "        \n",
     "        if support >= min_support:\n",
     "            output.insert(0,key)\n",
-    "        support_dict[key] = support\n",
+    "            support_dict[key] = support\n",
     "    return output, support_dict"
    ]
   },
@@ -337,7 +337,7 @@
     "    print('-'*30)\n",
     "    df  = df.sort_values('confidence',ascending=False).iloc[:max_display]\n",
     "    for i,row in df.iterrows():\n",
-    "        print(\"%.2f\" % float(row['confidence']),'\\t',set(row['antecedants']),'->',set(row['consequents']))"
+    "        print(\"%.2f\" % float(row['confidence']),'\\t',set(row['antecedents']),'->',set(row['consequents']))"
    ]
   },
   {

--- a/Exercises/05.Frequent_Itemsets/Frequent_itemsets_solution.ipynb
+++ b/Exercises/05.Frequent_Itemsets/Frequent_itemsets_solution.ipynb
@@ -186,7 +186,7 @@
     "        support = support_count[key]/num_transactions\n",
     "        if support >= min_support:\n",
     "            output.insert(0,key)\n",
-    "        support_dict[key] = support\n",
+    "            support_dict[key] = support\n",
     "    return output, support_dict"
    ]
   },
@@ -341,7 +341,7 @@
     "    print('-'*30)\n",
     "    df  = df.sort_values('confidence',ascending=False).iloc[:max_display]\n",
     "    for i,row in df.iterrows():\n",
-    "        print(\"%.2f\" % float(row['confidence']),'\\t',set(row['antecedants']),'->',set(row['consequents']))"
+    "        print(\"%.2f\" % float(row['confidence']),'\\t',set(row['antecedents']),'->',set(row['consequents']))"
    ]
   },
   {
@@ -691,24 +691,6 @@
     "{rain} → {clouds} support: 0.625 confidence: 1.0\n",
     "There are only two association rules with confidence equal to 1 and that is the final solution.\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Week 5, Frequent itemsets

Fix two small bugs in both Jupyter Notebooks:

- `get_support`: correctly indent the line `support_dict[key] = support` (thank you Pablo for noticing it: [moodle](https://moodle.epfl.ch/mod/forum/discuss.php?d=29679))
- `print_rules_mx`: fix spelling mistake -- replace "antecedants" with "antecedents" (as of now, if we execute the Jupyter Notebook from start to bottom a `KeyError: 'antecedants'` error appear ...)

Extra:
+ removed two extra empty cells at the end of `Frequent_itemsets_solution.ipynb`